### PR TITLE
Update students page with links to personal websites

### DIFF
--- a/students.html
+++ b/students.html
@@ -17,12 +17,12 @@ href="http://fonts.googleapis.com/css?family=Yanone+Kaffeesatz%7CDroid+Sans"
   <body>
     <div id="wrapper960" class="clearfix">
       <!-- <div id="toplinks"> -->
-      <!-- 	<ul class="toplinks_links"> -->
-      <!-- 		<li><a href="people.html">People</a></li> -->
-      <!-- 		<li><a href="#">Top link #2</a></li> -->
-      <!-- 		<li><a href="#">Top link #3</a></li> -->
-      <!-- 		<li><a href="#">Top link #4</a></li> -->
-      <!-- 	</ul> -->
+      <!--  <ul class="toplinks_links"> -->
+      <!--    <li><a href="people.html">People</a></li> -->
+      <!--    <li><a href="#">Top link #2</a></li> -->
+      <!--    <li><a href="#">Top link #3</a></li> -->
+      <!--    <li><a href="#">Top link #4</a></li> -->
+      <!--  </ul> -->
       <!-- </div> -->
       <div id="header" class="clearfix shadow">
         <div id="sitetitle" class="clearfix">
@@ -60,82 +60,93 @@ href="http://fonts.googleapis.com/css?family=Yanone+Kaffeesatz%7CDroid+Sans"
         <div style="float:left;width:31%;">
           <div class="inner">
             <ul style="list-style-type:none;">
-	      <li>Noah Brustle</li>
-              <li> <a href="http://www.cs.toronto.edu/%7Esoroush/"
-                  target="_blank">Soroush Ebadian</a> </li>
-	      
-              <li> <a href="http://www.cs.toronto.edu/%7Eedmonds/"
-                  target="_blank">Alex Edmonds</a> </li>
-              <li>Xing Hu</li>
-	      <li>Ziyang Jin</li>
-	      <li>Deepanshu Kush</li>
-	      <li>Christodoulos (Chris) Karavasilis</li>
-	      <li>Jeremy Ko</li>
-
-
+              <li>Noah Brustle</li>
+              <li>
+                <a href="https://www.cs.toronto.edu/%7Esoroush/" target="_blank">Soroush Ebadian</a>
+              </li>
+              <li>
+                <a href="https://www.cs.toronto.edu/%7Eedmonds/" target="_blank">Alex Edmonds</a>
+              </li>
+              <li>
+                <a href="https://www.cs.toronto.edu/%7Exing/" target="_blank">Xing Hu</a>
+              </li>
+              <li>
+                <a href="https://www.cs.toronto.edu/%7Eziyang/" target="_blank">Ziyang Jin</a>
+              </li>
+              <li>
+                <a href="https://www.cs.toronto.edu/%7Eckar/" target="_blank">Christodoulos Karavasilis</a>
+              </li>
+              <li>Jeremy Ko</li>
+              <li>
+                <a href="https://sites.google.com/view/deepkush/" target="_blank">Deepanshu Kush</a>
+              </li>
             </ul>
           </div>
         </div>
         <div style="float:left;width:31%;">
           <div class="inner">
             <ul style="list-style-type:none;">
-              <li> <a href="http://www.cs.toronto.edu/%7Elatifian/"
-                      target="_blank">Mohammad Latifian</a> </li>
-	      <li><a href="http://www.cs.toronto.edu/%7Elawrenceli/" target="_blank">Er Lu Lawrence Li</a></li>
-	      <li>Sky Li</li>
-	      <li>Xinyuan (Lily) Li</li>
-	      <li>Shi Hao Liu</li>
-	      <!-- <li>Hector Derwood Calum MacRury</li> -->
-              <li> <a href="http://www.cs.toronto.edu/%7Eemicha/"
-                  target="_blank">Evi Micha</a> </li>
-	      <li>Jordan Malek</li>
-	      <li>Sean Garnet Ovens</li>
-
-
+              <li>
+                <a href="https://www.cs.toronto.edu/%7Elatifian/" target="_blank">Mohammad Latifian</a>
+              </li>
+              <li>
+                <a href="https://www.cs.toronto.edu/%7Elawrenceli/" target="_blank">Lawrence Li</a>
+              </li>
+              <li>Lily Li</li>
+              <li>Sky Li</li>
+              <li>Jason (Shi Hao) Liu</li>
+              <li>Jordan Malek</li>
+              <li>
+                <a href="https://www.cs.toronto.edu/%7Eemicha/" target="_blank">Evi Micha</a>
+              </li>
+              <li>
+                <a href="https://www.seanovens.com/" target="_blank">Sean Ovens</a>
+              </li>
             </ul>
           </div>
         </div>
         <div style="float:left;width:31%;">
           <div class="inner">
             <ul style="list-style-type:none;">
-              <li><a href="http://www.cs.toronto.edu/%7Erosenthal/">
-                  Gregory Rosenthal </a></li>
-	      <li><a href="https://harrysha.com/" target="_blank">Harry Sha</a></li>
-              <li><a href="http://www.cs.toronto.edu/%7Eashe/" target="_blank">Adrian She</a></li>
-	      <li><a href="https://morganfshirley.com/"
-		     target="_blank">Morgan Shirley</a></li>
-	      <li>Devansh Shringi</li>
-	      <li>Haohua Tang</li>
-	      <li>Yibin Zhao</li>
-
-              <!-- <li> <a href="http://www.cs.toronto.edu/%7Etyrone/" -->
-              <!--     target="_blank">Tyrone Strangway</a> </li> -->
-              <!-- <li> <a href="http://www.cs.toronto.edu/%7Elezhu/" -->
-              <!--     target="_blank">Leqi (Jimmy) Zhu</a> </li> -->
+              <li>
+                <a href="https://www.cs.toronto.edu/%7Erosenthal/" target="_blank">Gregory Rosenthal</a>
+              </li>
+              <li>
+                <a href="https://harrysha.com/" target="_blank">Harry Sha</a>
+              </li>
+              <li>
+                <a href="https://www.cs.toronto.edu/%7Eashe/" target="_blank">Adrian She</a>
+              </li>
+              <li>
+                <a href="https://morganfshirley.com/" target="_blank">Morgan Shirley</a>
+              </li>
+              <li>
+                <a href="https://devansh99.github.io/" target="_blank">Devansh Shringi</a>
+              </li>
+              <li>Haohua Tang</li>
+              <li>Yibin Zhao</li>
             </ul>
           </div>
         </div>
       </div>
       <div id="footer" class="shadow">
-        <p>© <a href="http://andreasviklund.com/templates/inland/">Template
-
-            design</a> by <a href="http://andreasviklund.com/">andreasviklund.com</a></p>
+        <p>©Template design by <a href="https://andreasviklund.com/">andreasviklund.com</a></p>
       </div>
     </div>
     <script type="text/javascript">
-  	$(window).load(function() {
+    $(window).load(function() {
 
-  		//$('#nav li ul').hide().removeClass('fallback');
-  		$('#nav li').hover(
-    		function () {
-      	$('ul', this).stop().slideDown(0);
-    	},
-    	function () {
-      	$('ul', this).stop().slideUp(0);
-    	}
-  		);
+      //$('#nav li ul').hide().removeClass('fallback');
+      $('#nav li').hover(
+        function () {
+        $('ul', this).stop().slideDown(0);
+      },
+      function () {
+        $('ul', this).stop().slideUp(0);
+      }
+      );
 
-  	});
+    });
   </script>
   </body>
 </html>


### PR DESCRIPTION
This commit updates the students page on the theory group website. It adds links to each student's personal websites, if available. It also fixes the ordering of students names to follow alphabetical order by last name. It also changes students' names to their preferred names, which is usually the name they use when publishing papers.
