### PR TITLE
Fix links on the events page and revive the link to Theory Student Seminar

### DIFF
--- a/events.html
+++ b/events.html
@@ -24,7 +24,7 @@
 			<li><a href="#">Top link #4</a></li>
 		</ul>
 	</div>
--->
+	-->
 
 	<div id="header" class="clearfix shadow">
 		<div id="sitetitle" class="clearfix">
@@ -63,27 +63,19 @@
 
 	<div id="content" class="clearfix shadow">
 
-	  <!--<iframe src="https://calendar.google.com/calendar/embed?src=ut.theory%40gmail.com&ctz=America/Toronto" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>-->
+		<iframe style="width:100%" src="https://calendar.google.com/calendar/embed?title=UToronto%20Theory%20events&amp;showPrint=0&amp;showTabs=0&amp;showCalendars=0&amp;showTz=0&amp;mode=AGENDA&amp;height=300&amp;wkst=2&amp;bgcolor=%23FFFFFF&amp;src=ut.theory%40gmail.com&amp;color=%23B1365F&amp;ctz=America%2FToronto"
+		style="border-width:0" height="500" frameborder="0" scrolling="no"></iframe>
 
-	  <iframe style="width:100%" src="https://calendar.google.com/calendar/embed?title=UToronto%20Theory%20events&amp;showPrint=0&amp;showTabs=0&amp;showCalendars=0&amp;showTz=0&amp;mode=AGENDA&amp;height=300&amp;wkst=2&amp;bgcolor=%23FFFFFF&amp;src=ut.theory%40gmail.com&amp;color=%23B1365F&amp;ctz=America%2FToronto"
-	  style="border-width:0" height="500"
-	  frameborder="0" scrolling="no"></iframe>
+		<br><br>
+		<p><a href="pastseminars.html" target="_blank">Past seminar talks (2009-2016)</a></p>
 
-	  <br><br>
-	  <p><a href="pastseminars.html">Past seminar talks (2009-2016)</a></p>
+		<h3>On campus</h3>
 
-	  <h3>On campus</h3>
-	  <p><a href="http://web.cs.toronto.edu/news/events.htm"
-              rel="nofollow">DCS Events Calendar</a></p>
-
-          <!--<p><a href="http://www.cs.toronto.edu/%7Ewgeorge/tss.html">Theory Student Seminar</a><br>-->
-          </p><p><a
-href="http://www.utoronto.ca/reg/list_notices.pl?dept=maths&amp;time_frame=year">Department of Mathematics Seminar Listings</a></p>
-          <p><a href="http://www.fields.utoronto.ca/programs/">Fields Institute Events</a></p>
+		<p><a href="https://web.cs.toronto.edu/events" target="_blank" rel="nofollow">DCS Events Calendar</a></p>
+		<p><a href="https://www.cs.toronto.edu/tss/" target="_blank">Theory Student Seminar</a></p>
+		<p><a href="https://seminars.math.toronto.edu/seminars/" target="_blank">Department of Mathematics Seminar Listings</a></p>
+		<p><a href="http://www.fields.utoronto.ca/calendar" target="_blank">Fields Institute Events</a></p> <!-- does not support https -->
 	</div>
-
-
-
 
 	<!--
 	<div id="extended" class="clearfix shadow">
@@ -111,8 +103,7 @@ href="http://www.utoronto.ca/reg/list_notices.pl?dept=maths&amp;time_frame=year"
 	-->
 
 	<div id="footer" class="shadow">
-		<p>&copy; <a href="http://andreasviklund.com/templates/inland/">Template design</a> by
-		<a href="http://andreasviklund.com/">andreasviklund.com</a></p>
+		<p>&copy; Template design by <a href="https://andreasviklund.com/" target="_blank">andreasviklund.com</a></p>
 	</div>
 </div>
 
@@ -121,12 +112,12 @@ href="http://www.utoronto.ca/reg/list_notices.pl?dept=maths&amp;time_frame=year"
 
 		//$('#nav li ul').hide().removeClass('fallback');
 		$('#nav li').hover(
-  		function () {
-    	$('ul', this).stop().slideDown(0);
-  	},
-  	function () {
-    	$('ul', this).stop().slideUp(0);
-  	}
+		function () {
+		$('ul', this).stop().slideDown(0);
+	},
+	function () {
+		$('ul', this).stop().slideUp(0);
+	}
 		);
 
 		$('#slider').nivoSlider();


### PR DESCRIPTION
- Update students page with links to personal websites
- Updated theory faculty to remove Henry and Ben
- Update postdoc info
- Update faculty info
- Updated postdocs
- Update student alumni page
- Update postdoc alumni page
- Fix links on the events page and revives the link to Theory Student Seminar
