### PR TITLE
Use https and update links on home page, faculty page, and positions page

### DIFF
--- a/faculty.html
+++ b/faculty.html
@@ -15,15 +15,6 @@
 
 <body>
   <div id="wrapper960" class="clearfix">
-    <!-- <div id="toplinks"> -->
-    <!-- 	<ul class="toplinks_links"> -->
-    <!-- 		<li><a href="people.html">People</a></li> -->
-    <!-- 		<li><a href="#">Top link #2</a></li> -->
-    <!-- 		<li><a href="#">Top link #3</a></li> -->
-    <!-- 		<li><a href="#">Top link #4</a></li> -->
-    <!-- 	</ul> -->
-    <!-- </div> -->
-
 
     <div id="header" class="clearfix shadow">
       <div id="sitetitle" class="clearfix">
@@ -67,12 +58,12 @@
       <div id="trio2">
 	<div class="inner">
 	  <div class="fac_img">
-            <a href="http://www.cs.toronto.edu/%7Ebor/" target="_blank">
+            <a href="https://www.cs.toronto.edu/%7Ebor/" target="_blank">
 	      <img src="people/borodin2.jpg" height="130" width="130"
 	      /> </a>
 	  </div>
 	  <div class="fac_info">
-            <p> <a href="http://www.cs.toronto.edu/%7Ebor/" target="_blank"><strong>Allan Borodin</strong></a> <br /> Complexity Theory, <br />
+            <p> <a href="https://www.cs.toronto.edu/%7Ebor/" target="_blank"><strong>Allan Borodin</strong></a> <br /> Complexity Theory, <br />
               Online Algorithms, <br/>
 	      Game Theory
             </p>
@@ -80,19 +71,17 @@
         </div>
       </div>
 
-
-
       <div id="trio2">
 	<div class="inner">
 	  <div class="fac_img">
-	    <a href="http://www.cs.toronto.edu/%7Efaith" target="_blank">
+	    <a href="https://www.cs.toronto.edu/%7Efaith" target="_blank">
 	      <img src="people/faith.jpg" class="fac_img"
 		   height="130"
 		   width="130"
 		   /></a>
 	  </div>
 	  <div class="fac_info">
-	    <p> <a href="http://www.cs.toronto.edu/%7Efaith" target="_blank"><strong>Faith Ellen</strong>
+	    <p> <a href="https://www.cs.toronto.edu/%7Efaith" target="_blank"><strong>Faith Ellen</strong>
 	      </a> <br /> Distributed Complexity, <br />
 	      Data Structures, <br /> Lower Bounds</p>
 	  </div>
@@ -102,12 +91,12 @@
       <div id="trio2">
 	<div class="inner">
 	  <div class="fac_img">
-            <a href="http://www.cs.toronto.edu/%7Evassos/" target="_blank">
+            <a href="https://www.cs.toronto.edu/%7Evassos/" target="_blank">
 	      <img src="people/vassos.jpg" height="130" width="130"
 		   /></a>
 	  </div>
 	  <div class="fac_info">
-            <p> <a href="http://www.cs.toronto.edu/%7Evassos/" target="_blank"><strong>Vassos
+            <p> <a href="https://www.cs.toronto.edu/%7Evassos/" target="_blank"><strong>Vassos
                 Hadzilacos</strong></a> <br /> Distributed Computing
             </p>
 	  </div>
@@ -131,32 +120,29 @@
         </div>
       </div>
 
-	   
       <div id="trio3">
 	<div class="inner">
 	  <div class="fac_img">
-            <a href="http://www.cs.toronto.edu/%7Emolloy/" target="_blank"><img src="people/molloy.jpg"
+            <a href="https://www.cs.toronto.edu/%7Emolloy/" target="_blank"><img src="people/molloy.jpg"
 								height="130" width="130" /></a>
 	  </div>
 	  <div class="fac_info">
-            <p> <a href="http://www.cs.toronto.edu/%7Emolloy/" target="_blank"><strong>Michael
+            <p> <a href="https://www.cs.toronto.edu/%7Emolloy/" target="_blank"><strong>Michael
 		Molloy</strong></a> <br /> Graph Theory, <br/> Combinatorics</p>
 	  </div>
         </div>
       </div>
 
-
-
       <div id="trio1">
 	<div class="inner">
 	  <div class="fac_img">
-	    <a href="http://www.cs.toronto.edu/%7Eanikolov" target="_blank">
+	    <a href="https://www.cs.toronto.edu/%7Eanikolov" target="_blank">
 	      <img src="people/nikolov.jpg" height="130" class="fac_img"
 		   width="130"
 		   /></a>
 	  </div>
 	  <div class="fac_info">
-	    <p> <a href="http://www.cs.toronto.edu/%7Eanikolov" target="_blank"><strong>Aleksandar Nikolov</strong>
+	    <p> <a href="https://www.cs.toronto.edu/%7Eanikolov" target="_blank"><strong>Aleksandar Nikolov</strong>
 	      </a> <br /> Algorithms, <br />
 	      Discrepancy Theory, <br /> Privacy</p>
 	  </div>
@@ -166,10 +152,10 @@
       <div id="trio2">
 	<div class="inner">
 	  <div class="fac_img">
-            <a href="http://www.cs.toronto.edu/%7Etoni/" target="_blank"><img src="people/pitassi.jpg"  height="130" width="130" /></a>
+            <a href="https://www.cs.toronto.edu/%7Etoni/" target="_blank"><img src="people/pitassi.jpg"  height="130" width="130" /></a>
 	  </div>
 	  <div class="fac_info">
-            <p> <a href="http://www.cs.toronto.edu/%7Etoni/" target="_blank"><strong>Toniann
+            <p> <a href="https://www.cs.toronto.edu/%7Etoni/" target="_blank"><strong>Toniann
                 Pitassi</strong></a> <br /> Complexity Theory, <br/>
 	      Proof Complexity<br/>
 	      (On leave)
@@ -178,18 +164,16 @@
         </div>
       </div>
 
-
-
       <!-- <div id="trio2"> -->
       <!-- 	<div class="inner"> -->
       <!-- 	  <div class="fac_img"> -->
-      <!-- 	    <a href="http://www.math.toronto.edu/rossman/" target="_blank"> -->
+      <!-- 	    <a href="https://www.math.toronto.edu/rossman/" target="_blank"> -->
       <!-- 	      <img src="people/rossman.jpg" class="fac_img" -->
       <!-- 		   width="130" height="130" -->
       <!-- 		   /></a> -->
       <!-- 	  </div> -->
       <!-- 	  <div class="fac_info"> -->
-      <!-- 	    <p> <a href="http://www.math.toronto.edu/rossman/" target="_blank"><strong>Benjamin Rossman</strong> -->
+      <!-- 	    <p> <a href="https://www.math.toronto.edu/rossman/" target="_blank"><strong>Benjamin Rossman</strong> -->
       <!-- 	      </a> <br /> Circuit Complexity, <br /> -->
       <!-- 	      Logic<br/> -->
       <!-- 	      (On leave) -->
@@ -201,11 +185,11 @@
       <div id="trio2">
 	<div class="inner">
 	  <div class="fac_img">
-            <a href="http://www.cs.toronto.edu/%7Esachdeva/" target="_blank"><img src="people/sachdeva.jpg"
+            <a href="https://www.cs.toronto.edu/%7Esachdeva/" target="_blank"><img src="people/sachdeva.jpg"
 								  height="130" width="130" /></a>
 	  </div>
 	  <div class="fac_info">
-            <p> <a href="http://www.cs.toronto.edu/%7Esachdeva/" target="_blank"><strong>Sushant
+            <p> <a href="https://www.cs.toronto.edu/%7Esachdeva/" target="_blank"><strong>Sushant
                 Sachdeva</strong></a> <br /> Algorithms, <br />
 	      Optimization, <br /> Learning
             </p>
@@ -233,12 +217,12 @@
       <div id="trio3">
 	<div class="inner">
 	  <div class="fac_img">
-            <a href="http://www.cs.toronto.edu/%7Enisarg/" target="_blank">
+            <a href="https://www.cs.toronto.edu/%7Enisarg/" target="_blank">
 	      <img src="people/shah.jpg" height="130" width="130"
 								/></a>
 	  </div>
 	  <div class="fac_info">
-            <p> <a href="http://www.cs.toronto.edu/%7Enisarg/" target="_blank"><strong>Nisarg
+            <p> <a href="https://www.cs.toronto.edu/%7Enisarg/" target="_blank"><strong>Nisarg
 		Shah</strong></a> <br /> Fairness, Social Choice, <br/> Game Theory, <br/> Mechanism Design</p>
 	  </div>
         </div>
@@ -247,13 +231,13 @@
       <div id="trio2">
 	<div class="inner">
 	  <div class="fac_img">
-	    <a href="http://www.cs.cornell.edu/annual_report/toueg.htm" target="_blank">
+	    <a href="https://www.cs.cornell.edu/annual_report/toueg.htm" target="_blank">
 	      <img src="people/toueg.gif" height="130" class="fac_img"
 		   width="130"
 		   /></a>
 	  </div>
 	  <div class="fac_info">
-	    <p> <a href="http://www.cs.cornell.edu/annual_report/toueg.htm" target="_blank"><strong>Sam Toueg</strong>
+	    <p> <a href="https://www.cs.cornell.edu/annual_report/toueg.htm" target="_blank"><strong>Sam Toueg</strong>
 	      </a> <br />Distributed Computing</p>
 	  </div>
 	</div>
@@ -262,14 +246,14 @@
       <div id="trio3">
 	<div class="inner">
 	  <div class="fac_img">
-            <!-- <a href="http://www.henryyuen.net" target="_blank">
+            <!-- <a href="https://www.henryyuen.net" target="_blank">
 	      --> <img src="people/nathan.jpg" height="130"
 		       width="130" />
 	    <!-- </a> -->
 	  </div>
 	  <div class="fac_info">
             <p>
-	      <!-- <a href="http://www.henryyuen.net" -->
+	      <!-- <a href="https://www.henryyuen.net" -->
 	      <!-- 	   target="_blank"> -->
 		<strong>Nathan Wiebe</strong>
 	      <!-- </a> -->
@@ -277,17 +261,15 @@
 	  </div>
         </div>
       </div>
-
-
-      
+ 
       <!-- <div id="trio3"> -->
       <!-- 	<div class="inner"> -->
       <!-- 	  <div class="fac_img"> -->
-      <!--       <a href="http://www.henryyuen.net" target="_blank"><img src="people/henry.png" -->
+      <!--       <a href="https://www.henryyuen.net" target="_blank"><img src="people/henry.png" -->
       <!-- 						    height="130" width="130" /></a> -->
       <!-- 	  </div> -->
       <!-- 	  <div class="fac_info"> -->
-      <!--       <p> <a href="http://www.henryyuen.net" target="_blank"><strong>Henry Yuen</strong> -->
+      <!--       <p> <a href="https://www.henryyuen.net" target="_blank"><strong>Henry Yuen</strong> -->
       <!-- 	      </a> <br /> Quantum Computing, <br /> Quantum -->
       <!-- 	      Cryptography, <br /> Complexity Theory<br/> -->
       <!-- 	      (On leave)</p> -->
@@ -296,22 +278,20 @@
       <!-- </div> -->
 
     </div>
-
     
     <div id="extended" class="clearfix shadow">
       <a name="emeriti"></a>
       <h2>Emeriti Faculty</h2>
 
-
       <div id="trio2">
 	<div class="inner">
 	  <div class="fac_img">
-            <a href="http://www.cs.toronto.edu/%7Esacook/" target="_blank">
+            <a href="https://www.cs.toronto.edu/%7Esacook/" target="_blank">
 	      <img src="people/cook.jpg" height="130" width="130"
 		   /></a>
 	  </div>
 	  <div class="fac_info">
-            <p> <a href="http://www.cs.toronto.edu/%7Esacook/" target="_blank">
+            <p> <a href="https://www.cs.toronto.edu/%7Esacook/" target="_blank">
 		<strong>Stephen Cook</strong></a> <br /> Complexity Theory, <br />
 		Logic
             </p>
@@ -327,21 +307,20 @@
 		   /></a>
 	  </div>
 	  <div class="fac_info">
-            <p> <a href="Corneil-bio.htm"><strong>Derek Corneil</strong></a> <br />
+            <p> <a href="Corneil-bio.htm" target="_blank"><strong>Derek Corneil</strong></a> <br />
 	      Graph Theory</p>
 	  </div>
         </div>
       </div>
 
-      
       <div id="trio3">
 	<div class="inner">
 	  <div class="fac_img">
-            <a href="http://www.cs.toronto.edu/%7Erackoff/"><img src="people/rackoff.jpg"
+            <a href="https://www.cs.toronto.edu/%7Erackoff/"><img src="people/rackoff.jpg"
 								 height="130" width="130" /></a>
 	  </div>
 	  <div class="fac_info">
-            <p> <a href="http://www.cs.toronto.edu/%7Erackoff/" target="_blank">
+            <p> <a href="https://www.cs.toronto.edu/%7Erackoff/" target="_blank">
 		<strong>Charles Rackoff</strong></a> <br /> Cryptography,
 	      <br/> Complexity Theory</p>
 	  </div>
@@ -351,12 +330,12 @@
       <div id="trio2">
 	<div class="inner">
 	  <div class="fac_img">
-            <a href="http://utoronto.academia.edu/AlasdairUrquhart" target="_blank">
+            <a href="https://utoronto.academia.edu/AlasdairUrquhart" target="_blank">
 	      <img src="people/alasdair.jpg" height="130" width="130"
 		   /></a>
 	  </div>
 	  <div class="fac_info">
-            <p> <a href="http://utoronto.academia.edu/AlasdairUrquhart" target="_blank"><strong>Alasdair
+            <p> <a href="https://utoronto.academia.edu/AlasdairUrquhart" target="_blank"><strong>Alasdair
 		Urquhart</strong></a> <br /> Complexity of Proofs,
 	      <br /> Logic, <br /> History of Logic
             </p>
@@ -374,26 +353,17 @@
       <div class="inner">
         <ul style="list-style-type:none;">
           <li>Jankie Ramsook
-          <!-- <li><a href="http://www.cs.toronto.edu/~vargai/" target="_blank">Ingrid Varga</a> -->
+          <!-- <li><a href="https://www.cs.toronto.edu/~vargai/" target="_blank">Ingrid Varga</a> -->
         </ul>
       </div>
 
 
     </div>
 
-
-
-
-
-
-
-
-
-
-    <div id="footer" class="shadow">
-      <p>&copy; <a href="http://andreasviklund.com/templates/inland/">Template design</a> by
-	<a href="http://andreasviklund.com/">andreasviklund.com</a></p>
-    </div>
+  <div id="footer" class="shadow">
+    <p>&copy; Template design by
+				<a href="https://andreasviklund.com/" target="_blank">andreasviklund.com</a>
+		</p>
   </div>
 
   <script type="text/javascript">

--- a/index.html
+++ b/index.html
@@ -16,16 +16,7 @@ href="http://fonts.googleapis.com/css?family=Yanone+Kaffeesatz%7CDroid+Sans"
   </head>
   <body>
     <div id="wrapper960" class="clearfix">
-      <!--
-	<div id="toplinks">
-		<ul class="toplinks_links">
-			<li><a href="people.html">People</a></li>
-			<li><a href="#">Top link #2</a></li>
-			<li><a href="#">Top link #3</a></li>
-			<li><a href="#">Top link #4</a></li>
-		</ul>
-	</div>
--->
+
       <div id="header" class="clearfix shadow">
         <div id="sitetitle" class="clearfix">
           <h1><a href="index.html">Theory Group at UofT</a></h1>
@@ -62,24 +53,27 @@ href="http://fonts.googleapis.com/css?family=Yanone+Kaffeesatz%7CDroid+Sans"
       <div id="content" class="clearfix shadow">
         <h2>Welcome!</h2>
         <p> Welcome to the Theory Group at the <a
-            href="http://www.cs.toronto.edu/"> Department of Computer
-            Science</a>, <a href="http://www.toronto.edu/">University
-            of Toronto</a>! We study the theory of computation, and our
-          research investigates areas such as computational complexity
-          theory, graph algorithms, algorithmic game theory,
-          optimization, cryptography, distributed computing, quantum
-          computing, privacy, and more. </p>
+            href="https://web.cs.toronto.edu/" target="_blank">
+            Department of ComputerScience</a>, 
+            <a href="https://www.utoronto.ca/" target="_blank">
+            University of Toronto</a>! We study the theory of computation,
+            and our research investigates areas such as computational 
+            complexity theory, graph algorithms, algorithmic game theory,
+            optimization, cryptography, distributed computing, quantum
+            computing, privacy, and more.
+        </p>
         <p>Find out more about the members of our group and their
           research interests by navigating to the People menu above.
           Check out our <a href="events.html">Event Calendar</a>.
           Information about graduate courses offered by the group can be
-          found <a href="courses.html">here</a>. </p>
+          found <a href="courses.html">here</a>.
+        </p>
         <p> You will also find information about joining the group as a
           graduate student or as a postdoc <a href="positions.html">here</a>.
           Information on joining the Department as a faculty member can
           be found at the <a
-            href="http://web.cs.toronto.edu/dcs/contact/employmentopp.htm"
-            rel="nofollow">DCS employment opportunities page</a>.<br>
+            href="https://web.cs.toronto.edu/employment-opportunities"
+            rel="nofollow" target="_blank">DCS employment opportunities page</a>.
         </p>
         <p>Members of the department can access information about the
           theory group mailing lists <a
@@ -87,34 +81,13 @@ href="http://fonts.googleapis.com/css?family=Yanone+Kaffeesatz%7CDroid+Sans"
           <br>
         </p>
       </div>
-      <!--
-	<div id="extended" class="clearfix shadow">
-		<div id="trio1">
-			<div class="inner">
-				<h3>Standards-compliant code</h3>
-				<p>The Inland template is written with standards-compliant HTML5 and CSS3.</p>
-			</div>
-		</div>
 
-		<div id="trio2">
-			<div class="inner">
-				<h3>Slider included</h3>
-				<p>The slider is made with a jQuery plugin called <a href="http://nivo.dev7studios.com">Nivo Slider</a>, created by Gilbert Pellegrom of dev7studios and released under the <a href="http://www.opensource.org/licenses/mit-license.php">MIT Licence</a>.</p>
-			</div>
-		</div>
-
-		<div id="trio3">
-			<div class="inner">
-				<h3>Multiple layout options</h3>
-				<p>Single-column, two columns with left or right sidebars, three columns - or a combination of any two layout options.</p>
-			</div>
-		</div>
-	</div>
-	-->
       <div id="footer" class="shadow">
-        <p>© <a href="http://andreasviklund.com/templates/inland/">Template
-            design</a> by <a href="http://andreasviklund.com/">andreasviklund.com</a></p>
+        <p>© Template design by <a href="https://andreasviklund.com/"
+          target="_blank">andreasviklund.com</a>
+        </p>
       </div>
+
     </div>
     <script type="text/javascript">
 	$(window).load(function() {

--- a/positions.html
+++ b/positions.html
@@ -15,16 +15,6 @@
 
 <body>
 <div id="wrapper960" class="clearfix">
-	<!--
-	<div id="toplinks">
-		<ul class="toplinks_links">
-			<li><a href="people.html">People</a></li>
-			<li><a href="#">Top link #2</a></li>
-			<li><a href="#">Top link #3</a></li>
-			<li><a href="#">Top link #4</a></li>
-		</ul>
-	</div>
--->
 
 	<div id="header" class="clearfix shadow">
 		<div id="sitetitle" class="clearfix">
@@ -51,7 +41,6 @@
 		</div>
 	</div>
 
-
 	<div id="content" class="clearfix shadow">
 
 	  <h2>Graduate studies</h2>
@@ -60,8 +49,8 @@
 	    The University of Toronto is an exciting place to pursue
 	    graduate studies in theoretical computer science. Students
 	    interested in joining the Theory Group should apply
-	    through the Department of Computer
-	    Science <a href="http://web.cs.toronto.edu/Graduate/prospective_gradwhy.htm">website</a>,
+	    through <a href="https://web.cs.toronto.edu/graduate/prospective" 
+	    target="_blank">the Department of Computer Science website</a>,
 	    and indicate that they are interested in pursuing theory.
 	  </p>
 
@@ -71,6 +60,7 @@
 
 	              <h2>Postdoctoral positions in Algorithms and
             Theoretical Machine Learning</h2>
+            
             <p>Prof. Sushant Sachdeva is also accepting applications
 	      for a postdoctoral position beginning in Fall
 	      2023. Successful candidates will work with him on topics
@@ -79,9 +69,12 @@
 	      learning. Candidates must possess a PhD prior to
 	      starting and give evidence of an outstanding research
 	      record and potential.</p>
+
 <!-- <h2>Postdoctoral position in Computational Social Choice</h2> -->
 		  <!-- 	<p>Prof. Nisarg Shah is also accepting applications for up to two additional postdoctoral positions beginning in Fall 2020. Successful candidate(s) will work with him on topics such as (but not limited to): computational social choice, fairness and incentives in machine learning, algorithmic game theory, and mechanism design. The positions are for up to two years. Applicants should have (prior to starting) a PhD in computer science, economics, operations research, or a related field.</p> -->
+
 		  <h2>Applying to postdoctoral positions</h2>
+			
 			<p>Applicants should email their CV and
 			research statement to Theory Group Committee
 			(<a href="mailto:postdocapp@cs.toronto.edu">postdocapp@cs.toronto.edu</a>),
@@ -95,37 +88,12 @@
 			2022</font></strong>. (Late applications might
 			not receive full consideration.)</p>
 
-
 	</div>
-
-	<!--
-	<div id="extended" class="clearfix shadow">
-		<div id="trio1">
-			<div class="inner">
-				<h3>Standards-compliant code</h3>
-				<p>The Inland template is written with standards-compliant HTML5 and CSS3.</p>
-			</div>
-		</div>
-
-		<div id="trio2">
-			<div class="inner">
-				<h3>Slider included</h3>
-				<p>The slider is made with a jQuery plugin called <a href="http://nivo.dev7studios.com">Nivo Slider</a>, created by Gilbert Pellegrom of dev7studios and released under the <a href="http://www.opensource.org/licenses/mit-license.php">MIT Licence</a>.</p>
-			</div>
-		</div>
-
-		<div id="trio3">
-			<div class="inner">
-				<h3>Multiple layout options</h3>
-				<p>Single-column, two columns with left or right sidebars, three columns - or a combination of any two layout options.</p>
-			</div>
-		</div>
-	</div>
-	-->
 
 	<div id="footer" class="shadow">
-		<p>&copy; <a href="http://andreasviklund.com/templates/inland/">Template design</a> by
-		<a href="http://andreasviklund.com/">andreasviklund.com</a></p>
+		<p>&copy; Template design by 
+			<a href="https://andreasviklund.com/" target="_blank">andreasviklund.com</a>
+		</p>
 	</div>
 </div>
 


### PR DESCRIPTION
- Update students page with links to personal websites
- Updated theory faculty to remove Henry and Ben
- Update postdoc info
- Update faculty info
- Updated postdocs
- Update student alumni page
- Update postdoc alumni page
- Fix links on the events page and revives the link to Theory Student Seminar
- Use https and update links for home page, faculty page, and positions page
