### PR TITLE
Update the Courses Page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/courses.html
+++ b/courses.html
@@ -15,16 +15,6 @@
 
 <body>
 <div id="wrapper960" class="clearfix">
-	<!--
-	<div id="toplinks">
-		<ul class="toplinks_links">
-			<li><a href="people.html">People</a></li>
-			<li><a href="#">Top link #2</a></li>
-			<li><a href="#">Top link #3</a></li>
-			<li><a href="#">Top link #4</a></li>
-		</ul>
-	</div>
--->
 
 	<div id="header" class="clearfix shadow">
 		<div id="sitetitle" class="clearfix">
@@ -51,134 +41,176 @@
 		</div>
 	</div>
 
-
 	<div id="content" class="clearfix shadow">
 		<h2>Graduate Course offerings</h2>
 
+		<p>For the current graduate courses offered by the Department of Computer Science, please check it 
+			<a href="https://web.cs.toronto.edu/graduate/timetable" target="_blank">here</a>.
+		</p>
 
-		<h3>Fall 2021</h3>
-		<ul>
-		  <li>CSC 2221: Introduction to Theory of Distributed Computing</li>
-		</ul>
+		<div>
+			<h3>Winter 2023</h3>
+			<ul style="padding-left:2em">
+				<li>CSC 2404: Computability and Logic</li>
+				<li>CSC 2412: Algorithms for Private Data Analysis</li>
+				<li>CSC 2415: Impossibility Results for Distributed Computing</li>
+				<li>CSC 2429: Topics in the Theory of Computation: Algebraic Complexity Theory</li>
+			</ul>
+		</div>
 
-		<h3>Winter 2021</h3>
-		<ul>
-		  <li><a href="http://www.cs.toronto.edu/~nisarg/teaching/2556s21/"
-			 target="_blank">CSC 2556: Algorithms for
-		      Collective Decision Making</a>
-		  <li><a href="https://sachdevasushant.github.io/courses/18f-csc2421/index.html"
-			 target="_blank">
-		      CSC 2421: Graphs, Matrices, and Optimization</a>
-		</ul>
+		<div>
+			<h3>Fall 2022</h3>
+			<ul style="padding-left:2em">
+				<li>CSC 2221: Introduction to Theory of Distributed Computing</li>
+				<li>CSC 2240: Graphs, Matrices and Coninuous Optimization</li>
+				<li>CSC 2332: Introduction to Quantum Algorithms</li>
+				<li><a href="https://www.cs.toronto.edu/~bor/2420f22/" target="_blank">
+					CSC 2420: Algorithm Design, Analysis and Theory</a>
+				</li>
+				<li>CSC 2429: Topics of Theory of Computation: Error Correcting Codes</li>
+			</ul>
+		</div>
 
-		<h3>Fall 2020</h3>
-		<ul>
- 		  <li><a href="http://www.cs.toronto.edu/~anikolov/CSC2412F20/CSC2412.html"
-			 target="_blank">
-		      CSC 2412: Algorithms for Private Data
-		      Analysis</a></li>
-		  <li><a href="https://q.utoronto.ca/courses/179038" target="_blank">
-		      CSC 473: Advanced Algorithms</a></li>
-		  <li>CSC 2221: Introduction to Theory of Distributed Computing</li>
-		</ul>
+		<div>
+			<h3>Winter 2022</h3>
+			<ul style="padding-left:2em">
+				<li><a href="https://www.cs.toronto.edu/~bor/2421s22/" target="_blank">
+					CSC 2421: Topics in Algorithms: Online and other Myopic Algorithms</a>
+				</li>
+				<li><a href="https://www.cs.toronto.edu/~nisarg/teaching/2556s22/" 
+					target="_blank"> CSC 2556: Algorithms for Collective Descision Making</a>
+				</li>
+			</ul>
+		</div>
 
-		<h3>Winter 2020</h3>
-		<ul>
-		  <li><a href="http://www.cs.toronto.edu/~nisarg/teaching/2556s20/"
-			 target="_blank">CSC 2556: Algorithms for
-		      Collective Decision Making</a>
-		  <li><a href="http://www.cs.toronto.edu/~anikolov/CSC473W20/index.html"
-			 target="_blank">
-		      CSC 473: Advanced Algorithms</a>
-		</ul>
+		<div>
+			<h3>Fall 2021</h3>
+			<ul style="padding-left:2em">
+				<li>CSC 2221: Introduction to Theory of Distributed Computing</li>
+				<li><a href="https://www.math.toronto.edu/ssaraf/CSC2429F21/" target="_blank">
+					CSC 2429: Algebraic Gems in Theoretical Computer Science and Discrete Mathematics</a>
+				</li>
+			</ul>
+		</div>
 
-		<h3>Fall 2019</h3>
-		<ul>
- 			<li><a href="http://www.cs.toronto.edu/~anikolov/CSC2412F19/CSC2412.html"
-			 target="_blank">CSC 2412: Algorithms for Private Data Analysis</a>
-			<li><a href="http://www.cs.toronto.edu/~bor/2421f19/"
-			 target="_blank">CSC 2421: Topics in Algorithms: Online and other Myopic Algorithms</a>
-			<li><a href="http://henryyuen.net/classes/fall2019/"
-			 target="_blank">CSC 2451H/MAT 1751H: Quantum Computing, Foundations to Frontier</a>
-			<li><a href="">CSC 2541HF: Topics in Machine Learning - AI and Ethics</a>
-		</ul>
+		<div>
+			<h3>Winter 2021</h3>
+			<ul style="padding-left:2em">
+				<li><a href="https://sachdevasushant.github.io/courses/18f-csc2421/index.html"
+					target="_blank"> CSC 2421: Graphs, Matrices, and Optimization</a>
+				</li>
+				<li><a href="https://www.cs.toronto.edu/~nisarg/teaching/2556s21/"
+					target="_blank"> CSC 2556: Algorithms for Collective Decision Making</a>
+				</li>
+			</ul>
+		</div>
 
-		<h3>Winter 2019</h3>
-		<ul>
-			<li><a href="http://www.math.toronto.edu/rossman/CSC2429.html"
-			 target="_blank">CSC 2429/MAT 1304: Circuit Complexity</a>
-			<li><a href="http://www.cs.toronto.edu/~nisarg/teaching/2556s19/"
-			 target="_blank">CSC 2556: Algorithms for Collective Decision Making</a>
-		</ul>
+		<div>
+			<h3>Fall 2020</h3>
+			<ul style="padding-left:2em">
+				<li><a href="https://www.cs.toronto.edu/~anikolov/CSC2412F20/CSC2412.html"
+					target="_blank"> CSC 2412: Algorithms for Private Data Analysis</a>
+				</li>
+				<li>CSC 2221: Introduction to Theory of Distributed Computing</li>
+			</ul>
+		</div>
 
-		<h3>Fall 2018</h3>
-		<ul>
-		  <li><a href="http://www.cs.toronto.edu/~anikolov/CSC2412F18/CSC2412.html"
-			 target="_blank">CSC 2412: Algorithms for Private Data Analysis</a>
-			<li><a href="https://sachdevasushant.github.io/courses/18f-csc2421/index.html"
-			 target="_blank">CSC 2421: Graphs, Matrices, and Optimization</a>
- 			<li><a href="http://www.cs.toronto.edu/~rackoff/2426f18/"
-			 target="_blank">CSC 2426: Fundamentals of Cryptography</a>
-			<li><a href="http://henryyuen.net/classes/fall2018/"
-			 target="_blank">CSC 2451H/MAT 1751H: Quantum Computing, Foundations to Frontier</a>
-		</ul>
+		<div>
+			<h3>Winter 2020</h3>
+			<ul style="padding-left:2em">
+				<li><a href="https://www.cs.toronto.edu/~nisarg/teaching/2556s20/"
+					target="_blank"> CSC 2556: Algorithms for Collective Decision Making</a>
+				</li>
+			</ul>
+		</div>
 
-		<br />
+		<div>
+			<h3>Fall 2019</h3>
+			<ul style="padding-left:2em">
+				<li><a href="https://www.cs.toronto.edu/~anikolov/CSC2412F19/CSC2412.html"
+					target="_blank">CSC 2412: Algorithms for Private Data Analysis</a>
+				</li>
+				<li><a href="https://www.cs.toronto.edu/~bor/2421f19/" target="_blank">
+					CSC 2421: Topics in Algorithms: Online and other Myopic Algorithms</a>
+				</li>
+				<li><a href="https://henryyuen.net/classes/fall2019/" target="_blank">
+					CSC 2451: Quantum Computing, Foundations to Frontier</a>
+				</li>
+				<li>CSC 2541: Topics in Machine Learning - AI and Ethics</li>
+			</ul>
+		</div>
+
+		<div>
+			<h3>Winter 2019</h3>
+			<ul style="padding-left:2em">
+				<li><a href="https://www.math.toronto.edu/rossman/CSC2429.html"
+					target="_blank">CSC 2429: Circuit Complexity</a>
+				</li>
+				<li><a href="https://www.cs.toronto.edu/~nisarg/teaching/2556s19/"
+					target="_blank">CSC 2556: Algorithms for Collective Decision Making</a>
+				</li>
+			</ul>
+		</div>
+
+		<div>
+			<h3>Fall 2018</h3>
+			<ul style="padding-left:2em">
+				<li><a href="https://www.cs.toronto.edu/~anikolov/CSC2412F18/CSC2412.html"
+					target="_blank">CSC 2412: Algorithms for Private Data Analysis</a>
+				</li>
+				<li><a href="https://sachdevasushant.github.io/courses/18f-csc2421/index.html"
+					target="_blank">CSC 2421: Graphs, Matrices, and Optimization</a>
+				</li>
+				<li><a href="https://www.cs.toronto.edu/~rackoff/2426f18/"
+					target="_blank">CSC 2426: Fundamentals of Cryptography</a>
+				</li>
+				<li><a href="https://henryyuen.net/classes/fall2018/"
+					target="_blank">CSC 2451: Quantum Computing, Foundations to Frontier</a>
+				</li>
+			</ul>
+		</div>
+
+		<br/>
 		<h3>Past Course Offerings</h3>
-		<ul>
-		  <li><a href="http://www.cs.toronto.edu/~anikolov/csc2414.html">CSC 2414: Discrepancy Theory in Computer Science</a>
-		  <li><a href="https://sachdevasushant.github.io/courses/17f-csc2421/index.html"
-			 target="_blank"> CSC 2421: Fast Algorithms via
-		      Continuous Methods</a></li>
-		  <li><a href="http://www.math.toronto.edu/rossman/CSC2429.html">CSC 2429/MAT 1304: Circuit Complexity</a>
-			<li><a href="https://www.cs.toronto.edu/~toni/Courses/Proofs-SOS-2018/CS2429.html">CSC 2429: Proof Complexity, Mathematical Programming, and Algorithms</a>
-			<li><a href="https://www.cs.toronto.edu/~toni/Courses/CommComplexity2014/CS2429.html">CSC 2429: Communication Complexity, Applications and New Directions</a>
-			<li><a href="http://www.cs.toronto.edu/~nisarg/teaching/2556s18/">CSC 2556: Algorithms for Collective Decision Making</a>
- 		</ul>
+		<ul style="padding-left:2em">
+			<li><a href="https://www.cs.toronto.edu/~anikolov/csc2414.html" target="_blank">
+				CSC 2414: Discrepancy Theory in Computer Science</a>
+			</li>
+			<li><a href="https://www.cs.toronto.edu/~faith/2415.html" target="_blank">
+				CSC 2415: Impossibility Results for Distributed Computing</a>
+			</li>
+			<li><a href="https://sachdevasushant.github.io/courses/17f-csc2421/index.html" target="_blank">
+				CSC 2421: Fast Algorithms via Continuous Methods</a>
+			</li>
+			<li><a href="https://www.math.toronto.edu/rossman/CSC2429.html" target="_blank">
+				CSC 2429: Circuit Complexity</a>
+			</li>
+			<li><a href="https://www.cs.toronto.edu/~toni/Courses/Proofs-SOS-2018/CS2429.html" target="_blank">
+				CSC 2429: Proof Complexity, Mathematical Programming, and Algorithms</a>
+			</li>
+			<li><a href="https://www.cs.toronto.edu/~toni/Courses/CommComplexity2014/CS2429.html" target="_blank">
+				CSC 2429: Communication Complexity, Applications and New Directions</a>
+			</li>
+			<li><a href="https://www.cs.toronto.edu/~nisarg/teaching/2556s18/" target="_blank">
+				CSC 2556: Algorithms for Collective Decision Making</a>
+			</li>
+		</ul>
 	</div>
-
-	<!--
-	<div id="extended" class="clearfix shadow">
-		<div id="trio1">
-			<div class="inner">
-				<h3>Standards-compliant code</h3>
-				<p>The Inland template is written with standards-compliant HTML5 and CSS3.</p>
-			</div>
-		</div>
-
-		<div id="trio2">
-			<div class="inner">
-				<h3>Slider included</h3>
-				<p>The slider is made with a jQuery plugin called <a href="http://nivo.dev7studios.com">Nivo Slider</a>, created by Gilbert Pellegrom of dev7studios and released under the <a href="http://www.opensource.org/licenses/mit-license.php">MIT Licence</a>.</p>
-			</div>
-		</div>
-
-		<div id="trio3">
-			<div class="inner">
-				<h3>Multiple layout options</h3>
-				<p>Single-column, two columns with left or right sidebars, three columns - or a combination of any two layout options.</p>
-			</div>
-		</div>
-	</div>
-	-->
 
 	<div id="footer" class="shadow">
-		<p>&copy; <a href="http://andreasviklund.com/templates/inland/">Template design</a> by
-		<a href="http://andreasviklund.com/">andreasviklund.com</a></p>
+		<p>&copy; Template design by <a href="https://andreasviklund.com/" target="_blank">andreasviklund.com</a></p>
 	</div>
 </div>
 
 <script type="text/javascript">
 	$(window).load(function() {
-
-		//$('#nav li ul').hide().removeClass('fallback');
 		$('#nav li').hover(
-  		function () {
-    	$('ul', this).stop().slideDown(0);
-  	},
-  	function () {
-    	$('ul', this).stop().slideUp(0);
-  	}
+			function () {
+				$('ul', this).stop().slideDown(0);
+			},
+			function () {
+				$('ul', this).stop().slideUp(0);
+			}
 		);
 
 		$('#slider').nivoSlider();


### PR DESCRIPTION
- Update students page with links to personal websites
- Updated theory faculty to remove Henry and Ben
- Update postdoc info
- Update faculty info
- Updated postdocs
- Update student alumni page
- Update postdoc alumni page
- Fix links on the events page and revives the link to Theory Student Seminar
- Use https and update links for home page, faculty page, and positions page
- Fix Typo in the Home Page and Add Visitors
- Update the Courses Page
