### PR TITLE
Fix foramtting on alumni and postdocs page, add Malcolm to faculty page

### DIFF
--- a/alumni.html
+++ b/alumni.html
@@ -65,7 +65,7 @@
       For a list of our postdoc alumni, click <a href="postdocs_visitors.html">here</a>.
       <br />
       <br />
-      <div class="inner">
+      <div class="inner" style="padding-left: 1em;">
         <ul>
           <li><a href="https://www.cs.toronto.edu/%7Ecmacrury/" target="_blank">
               Calum MacRury</a> (Ph.D. - Postdoc at Columbia University)</li>

--- a/faculty.html
+++ b/faculty.html
@@ -18,37 +18,27 @@
 
     <div id="header" class="clearfix shadow">
       <div id="sitetitle" class="clearfix">
-	<h1><a href="index.html">Theory Group at UofT</a></h1>
+        <h1><a href="index.html">Theory Group at UofT</a></h1>
       </div>
 
       <div id="nav" class="clearfix">
-	<ul>
-	  <li><a href="index.html">Home</a></li>
-	  <li>
-        <a class="current" href="#">People</a>
-        <ul class="fallback">
-            <li><a href="faculty.html">Faculty and Staff</a></li>
-            <li><a href="postdocs_visitors.html">Postdocs and Visitors</a></li>
-            <li><a href="students.html">Students</a></li>
-            <li><a href="alumni.html">Alumni</a></li>
+        <ul>
+          <li><a href="index.html">Home</a></li>
+          <li><a class="current" href="#">People</a>
+              <ul class="fallback">
+                <li><a href="faculty.html">Faculty and Staff</a></li>
+                <li><a href="postdocs_visitors.html">Postdocs and Visitors</a></li>
+                <li><a href="students.html">Students</a></li>
+                <li><a href="alumni.html">Alumni</a></li>
+              </ul>
+          </li>
+          <li><a href="research.html">Research</a></li>
+          <li><a href="events.html">Events</a></li>
+          <li><a href="courses.html">Courses</a></li>
+          <li><a href="positions.html">Positions</a></li>
         </ul>
-    </li>
-	  <li><a href="research.html">Research</a></li>
-	  <li><a href="events.html">Events</a></li>
-	  <li><a href="courses.html">Courses</a></li>
-	  <li><a href="positions.html">Positions</a></li>
-	</ul>
       </div>
     </div>
-
-    <!--div class="slider-wrapper">
-    <div id="slider" class="nivoSlider">
-      <img src="images/slider0.jpg" alt="" />
-      <img src="images/slider1.jpg" alt="" />
-      <img src="images/slider2.jpg" alt="" />
-      <img src="images/slider3.jpg" alt="" />
-      <img src="images/slider4.jpg" alt="" />
-    </div> -->
 
     <div id="extended" class="clearfix shadow">
 
@@ -56,330 +46,322 @@
       <h2>Faculty</h2>
 
       <div id="trio2">
-	<div class="inner">
-	  <div class="fac_img">
+        <div class="inner">
+          <div class="fac_img">
             <a href="https://www.cs.toronto.edu/%7Ebor/" target="_blank">
-	      <img src="people/borodin2.jpg" height="130" width="130"
-	      /> </a>
-	  </div>
-	  <div class="fac_info">
-            <p> <a href="https://www.cs.toronto.edu/%7Ebor/" target="_blank"><strong>Allan Borodin</strong></a> <br /> Complexity Theory, <br />
-              Online Algorithms, <br/>
-	      Game Theory
+              <img src="people/borodin2.jpg" height="130" width="130"/>
+            </a>
+          </div>
+          <div class="fac_info">
+            <p><a href="https://www.cs.toronto.edu/%7Ebor/" target="_blank">
+              <strong>Allan Borodin</strong></a> <br> Complexity Theory, <br>
+              Online Algorithms, <br/>Game Theory
             </p>
-	  </div>
+          </div>
         </div>
       </div>
 
       <div id="trio2">
-	<div class="inner">
-	  <div class="fac_img">
-	    <a href="https://www.cs.toronto.edu/%7Efaith" target="_blank">
-	      <img src="people/faith.jpg" class="fac_img"
-		   height="130"
-		   width="130"
-		   /></a>
-	  </div>
-	  <div class="fac_info">
-	    <p> <a href="https://www.cs.toronto.edu/%7Efaith" target="_blank"><strong>Faith Ellen</strong>
-	      </a> <br /> Distributed Complexity, <br />
-	      Data Structures, <br /> Lower Bounds</p>
-	  </div>
-	</div>
+        <div class="inner">
+          <div class="fac_img">
+            <a href="https://www.cs.toronto.edu/%7Efaith" target="_blank">
+              <img src="people/faith.jpg" class="fac_img" height="130" width="130"/>
+            </a>
+          </div>
+          <div class="fac_info">
+            <p><a href="https://www.cs.toronto.edu/%7Efaith" target="_blank">
+              <strong>Faith Ellen</strong></a> <br> Distributed Complexity, <br>
+              Data Structures, <br> Lower Bounds</p>
+          </div>
+        </div>
       </div>
 
       <div id="trio2">
-	<div class="inner">
-	  <div class="fac_img">
+        <div class="inner">
+          <div class="fac_img">
             <a href="https://www.cs.toronto.edu/%7Evassos/" target="_blank">
-	      <img src="people/vassos.jpg" height="130" width="130"
-		   /></a>
-	  </div>
-	  <div class="fac_info">
-            <p> <a href="https://www.cs.toronto.edu/%7Evassos/" target="_blank"><strong>Vassos
-                Hadzilacos</strong></a> <br /> Distributed Computing
+              <img src="people/vassos.jpg" height="130" width="130"/>
+            </a>
+          </div>
+          <div class="fac_info">
+            <p><a href="https://www.cs.toronto.edu/%7Evassos/" target="_blank">
+              <strong>Vassos Hadzilacos</strong></a> <br> Distributed Computing
             </p>
-	  </div>
+          </div>
         </div>
       </div>
 
-           <div id="trio2">
-	<div class="inner">
-	  <div class="fac_img">
-            <a href="https://www.math.toronto.edu/swastik/"
-	       target="_blank"><img src="people/swastik.jpg"
-								  height="130" width="130" /></a>
-	  </div>
-	  <div class="fac_info">
-            <p> <a href="https://www.math.toronto.edu/swastik/"
-	      target="_blank"><strong>Swastik Kopparty</strong></a>
-	      <br /> Complexity Theory, <br />
-	      Error-Correcting Codes, Pseudorandomness
+      <div id="trio2">
+        <div class="inner">
+          <div class="fac_img">
+            <a href="https://www.math.toronto.edu/swastik/" target="_blank">
+              <img src="people/swastik.jpg" height="130" width="130" /></a>
+          </div>
+          <div class="fac_info">
+            <p><a href="https://www.math.toronto.edu/swastik/" target="_blank">
+              <strong>Swastik Kopparty</strong></a> <br> Complexity Theory, <br>
+              Error-Correcting Codes, Pseudorandomness
             </p>
-	  </div>
+          </div>
         </div>
       </div>
 
       <div id="trio3">
-	<div class="inner">
-	  <div class="fac_img">
-            <a href="https://www.cs.toronto.edu/%7Emolloy/" target="_blank"><img src="people/molloy.jpg"
-								height="130" width="130" /></a>
-	  </div>
-	  <div class="fac_info">
-            <p> <a href="https://www.cs.toronto.edu/%7Emolloy/" target="_blank"><strong>Michael
-		Molloy</strong></a> <br /> Graph Theory, <br/> Combinatorics</p>
-	  </div>
+        <div class="inner">
+          <div class="fac_img">
+            <a href="https://www.cs.toronto.edu/%7Emolloy/" target="_blank">
+              <img src="people/molloy.jpg" height="130" width="130" /></a>
+          </div>
+          <div class="fac_info">
+            <p><a href="https://www.cs.toronto.edu/%7Emolloy/" target="_blank">
+              <strong>Michael Molloy</strong></a> <br> Graph Theory, <br>
+              Combinatorics
+            </p>
+          </div>
         </div>
       </div>
 
       <div id="trio1">
-	<div class="inner">
-	  <div class="fac_img">
-	    <a href="https://www.cs.toronto.edu/%7Eanikolov" target="_blank">
-	      <img src="people/nikolov.jpg" height="130" class="fac_img"
-		   width="130"
-		   /></a>
-	  </div>
-	  <div class="fac_info">
-	    <p> <a href="https://www.cs.toronto.edu/%7Eanikolov" target="_blank"><strong>Aleksandar Nikolov</strong>
-	      </a> <br /> Algorithms, <br />
-	      Discrepancy Theory, <br /> Privacy</p>
-	  </div>
-	</div>
+        <div class="inner">
+          <div class="fac_img">
+            <a href="https://www.cs.toronto.edu/%7Eanikolov" target="_blank">
+              <img src="people/nikolov.jpg" height="130" class="fac_img" width="130"/>
+            </a>
+          </div>
+          <div class="fac_info">
+            <p><a href="https://www.cs.toronto.edu/%7Eanikolov" target="_blank">
+              <strong>Aleksandar Nikolov</strong> </a> <br> Algorithms, <br>
+              Discrepancy Theory, <br> Privacy</p>
+          </div>
+        </div>
       </div>
 
       <div id="trio2">
-	<div class="inner">
-	  <div class="fac_img">
-            <a href="https://www.cs.toronto.edu/%7Etoni/" target="_blank"><img src="people/pitassi.jpg"  height="130" width="130" /></a>
-	  </div>
-	  <div class="fac_info">
-            <p> <a href="https://www.cs.toronto.edu/%7Etoni/" target="_blank"><strong>Toniann
-                Pitassi</strong></a> <br /> Complexity Theory, <br/>
-	      Proof Complexity<br/>
-	      (On leave)
+        <div class="inner">
+          <div class="fac_img">
+            <a href="https://www.cs.toronto.edu/%7Etoni/" target="_blank">
+              <img src="people/pitassi.jpg"  height="130" width="130" /></a>
+          </div>
+          <div class="fac_info">
+            <p><a href="https://www.cs.toronto.edu/%7Etoni/" target="_blank">
+              <strong>Toniann Pitassi</strong></a> <br> Complexity Theory, <br>
+              Proof Complexity<br> (On leave)
             </p>
-	  </div>
+          </div>
         </div>
       </div>
 
       <!-- <div id="trio2"> -->
-      <!-- 	<div class="inner"> -->
-      <!-- 	  <div class="fac_img"> -->
-      <!-- 	    <a href="https://www.math.toronto.edu/rossman/" target="_blank"> -->
-      <!-- 	      <img src="people/rossman.jpg" class="fac_img" -->
-      <!-- 		   width="130" height="130" -->
-      <!-- 		   /></a> -->
-      <!-- 	  </div> -->
-      <!-- 	  <div class="fac_info"> -->
-      <!-- 	    <p> <a href="https://www.math.toronto.edu/rossman/" target="_blank"><strong>Benjamin Rossman</strong> -->
-      <!-- 	      </a> <br /> Circuit Complexity, <br /> -->
-      <!-- 	      Logic<br/> -->
-      <!-- 	      (On leave) -->
-      <!-- 	    </p> -->
-      <!-- 	  </div> -->
-      <!-- 	</div> -->
+      <!--  <div class="inner"> -->
+      <!--    <div class="fac_img"> -->
+      <!--      <a href="https://www.math.toronto.edu/rossman/" target="_blank"> -->
+      <!--        <img src="people/rossman.jpg" class="fac_img" -->
+      <!--       width="130" height="130" -->
+      <!--       /></a> -->
+      <!--    </div> -->
+      <!--    <div class="fac_info"> -->
+      <!--      <p> <a href="https://www.math.toronto.edu/rossman/" target="_blank"><strong>Benjamin Rossman</strong> -->
+      <!--        </a> <br> Circuit Complexity, <br> -->
+      <!--        Logic<br/> -->
+      <!--        (On leave) -->
+      <!--      </p> -->
+      <!--    </div> -->
+      <!--  </div> -->
       <!-- </div> -->
 
       <div id="trio2">
-	<div class="inner">
-	  <div class="fac_img">
-            <a href="https://www.cs.toronto.edu/%7Esachdeva/" target="_blank"><img src="people/sachdeva.jpg"
-								  height="130" width="130" /></a>
-	  </div>
-	  <div class="fac_info">
-            <p> <a href="https://www.cs.toronto.edu/%7Esachdeva/" target="_blank"><strong>Sushant
-                Sachdeva</strong></a> <br /> Algorithms, <br />
-	      Optimization, <br /> Learning
+        <div class="inner">
+          <div class="fac_img">
+            <a href="https://www.cs.toronto.edu/%7Esachdeva/" target="_blank">
+              <img src="people/sachdeva.jpg" height="130" width="130" /></a>
+          </div>
+          <div class="fac_info">
+            <p><a href="https://www.cs.toronto.edu/%7Esachdeva/" target="_blank">
+              <strong>Sushant Sachdeva</strong></a> <br> Algorithms, <br>
+              Optimization, <br> Learning
             </p>
-	  </div>
+          </div>
         </div>
       </div>
 
       <div id="trio2">
-	<div class="inner">
-	  <div class="fac_img">
-            <a href="https://www.math.toronto.edu/ssaraf/"
-	       target="_blank"><img src="people/shubhangi.jpg"
-								  height="130" width="130" /></a>
-	  </div>
-	  <div class="fac_info">
-            <p> <a href="https://www.math.toronto.edu/ssaraf/"
-	      target="_blank"><strong>Shubhangi Saraf</strong></a>
-	      <br /> Complexity Theory, <br />
-	      Algebraic Computation
+        <div class="inner">
+          <div class="fac_img">
+            <a href="https://www.math.toronto.edu/ssaraf/" target="_blank">
+              <img src="people/shubhangi.jpg" height="130" width="130" /></a>
+          </div>
+          <div class="fac_info">
+            <p><a href="https://www.math.toronto.edu/ssaraf/" target="_blank">
+              <strong>Shubhangi Saraf</strong></a> <br> Complexity Theory, <br>
+              Algebraic Computation
             </p>
-	  </div>
+          </div>
         </div>
       </div>
 
       <div id="trio3">
-	<div class="inner">
-	  <div class="fac_img">
+        <div class="inner">
+          <div class="fac_img">
             <a href="https://www.cs.toronto.edu/%7Enisarg/" target="_blank">
-	      <img src="people/shah.jpg" height="130" width="130"
-								/></a>
-	  </div>
-	  <div class="fac_info">
-            <p> <a href="https://www.cs.toronto.edu/%7Enisarg/" target="_blank"><strong>Nisarg
-		Shah</strong></a> <br /> Fairness, Social Choice, <br/> Game Theory, <br/> Mechanism Design</p>
-	  </div>
+            <img src="people/shah.jpg" height="130" width="130"/></a>
+          </div>
+          <div class="fac_info">
+            <p><a href="https://www.cs.toronto.edu/%7Enisarg/" target="_blank">
+              <strong>Nisarg Shah</strong></a> <br> Fairness, Social Choice, <br>
+              Game Theory, <br> Mechanism Design
+            </p>
+          </div>
         </div>
       </div>
 
       <div id="trio2">
-	<div class="inner">
-	  <div class="fac_img">
-	    <a href="https://www.cs.cornell.edu/annual_report/toueg.htm" target="_blank">
-	      <img src="people/toueg.gif" height="130" class="fac_img"
-		   width="130"
-		   /></a>
-	  </div>
-	  <div class="fac_info">
-	    <p> <a href="https://www.cs.cornell.edu/annual_report/toueg.htm" target="_blank"><strong>Sam Toueg</strong>
-	      </a> <br />Distributed Computing</p>
-	  </div>
-	</div>
+        <div class="inner">
+          <div class="fac_img">
+            <a href="https://www.cs.cornell.edu/annual_report/toueg.htm" target="_blank">
+              <img src="people/toueg.gif" height="130" class="fac_img" width="130"/></a>
+          </div>
+          <div class="fac_info">
+            <p><a href="https://www.cs.cornell.edu/annual_report/toueg.htm" target="_blank">
+              <strong>Sam Toueg</strong></a> <br>Distributed Computing
+            </p>
+          </div>
+        </div>
       </div>
 
       <div id="trio3">
-	<div class="inner">
-	  <div class="fac_img">
-            <!-- <a href="https://www.henryyuen.net" target="_blank">
-	      --> <img src="people/nathan.jpg" height="130"
-		       width="130" />
-	    <!-- </a> -->
-	  </div>
-	  <div class="fac_info">
-            <p>
-	      <!-- <a href="https://www.henryyuen.net" -->
-	      <!-- 	   target="_blank"> -->
-		<strong>Nathan Wiebe</strong>
-	      <!-- </a> -->
-	      <br /> Quantum Algorithms, <br/> Quantum Machine Learning</p>
-	  </div>
+        <div class="inner">
+          <div class="fac_img">
+            <a href="https://cqiqc.physics.utoronto.ca/people/nathan-wiebe/" target="_blank">
+              <img src="people/nathan.jpg" height="130" width="130" /></a>
+          </div>
+          <div class="fac_info">
+            <p><a href="https://cqiqc.physics.utoronto.ca/people/nathan-wiebe/" target="_blank">
+              <strong>Nathan Wiebe</strong></a><br> Quantum Algorithms, <br>
+              Quantum Machine Learning
+            </p>
+          </div>
         </div>
       </div>
  
       <!-- <div id="trio3"> -->
-      <!-- 	<div class="inner"> -->
-      <!-- 	  <div class="fac_img"> -->
+      <!--  <div class="inner"> -->
+      <!--    <div class="fac_img"> -->
       <!--       <a href="https://www.henryyuen.net" target="_blank"><img src="people/henry.png" -->
-      <!-- 						    height="130" width="130" /></a> -->
-      <!-- 	  </div> -->
-      <!-- 	  <div class="fac_info"> -->
+      <!--                height="130" width="130" /></a> -->
+      <!--    </div> -->
+      <!--    <div class="fac_info"> -->
       <!--       <p> <a href="https://www.henryyuen.net" target="_blank"><strong>Henry Yuen</strong> -->
-      <!-- 	      </a> <br /> Quantum Computing, <br /> Quantum -->
-      <!-- 	      Cryptography, <br /> Complexity Theory<br/> -->
-      <!-- 	      (On leave)</p> -->
-      <!-- 	  </div> -->
+      <!--        </a> <br> Quantum Computing, <br> Quantum -->
+      <!--        Cryptography, <br> Complexity Theory<br/> -->
+      <!--        (On leave)</p> -->
+      <!--    </div> -->
       <!--   </div> -->
       <!-- </div> -->
 
     </div>
-    
+
     <div id="extended" class="clearfix shadow">
       <a name="emeriti"></a>
       <h2>Emeriti Faculty</h2>
 
       <div id="trio2">
-	<div class="inner">
-	  <div class="fac_img">
+        <div class="inner">
+          <div class="fac_img">
             <a href="https://www.cs.toronto.edu/%7Esacook/" target="_blank">
-	      <img src="people/cook.jpg" height="130" width="130"
-		   /></a>
-	  </div>
-	  <div class="fac_info">
-            <p> <a href="https://www.cs.toronto.edu/%7Esacook/" target="_blank">
-		<strong>Stephen Cook</strong></a> <br /> Complexity Theory, <br />
-		Logic
+              <img src="people/cook.jpg" height="130" width="130"/></a>
+          </div>
+          <div class="fac_info">
+            <p><a href="https://www.cs.toronto.edu/%7Esacook/" target="_blank">
+              <strong>Stephen Cook</strong></a> <br> Complexity Theory, <br>
+              Logic
             </p>
-	  </div>
+          </div>
         </div>
       </div>
 
       <div id="trio3">
-	<div class="inner">
-	  <div class="fac_img">
-            <a href="Corneil-bio.htm">
-	      <img src="people/corneil.jpg" height="130" width="130"
-		   /></a>
-	  </div>
-	  <div class="fac_info">
-            <p> <a href="Corneil-bio.htm" target="_blank"><strong>Derek Corneil</strong></a> <br />
-	      Graph Theory</p>
-	  </div>
+        <div class="inner">
+          <div class="fac_img">
+            <a href="Corneil-bio.htm" target="_blank">
+              <img src="people/corneil.jpg" height="130" width="130"/></a>
+          </div>
+          <div class="fac_info">
+            <p><a href="Corneil-bio.htm" target="_blank">
+              <strong>Derek Corneil</strong></a> <br>Graph Theory
+            </p>
+          </div>
         </div>
       </div>
 
       <div id="trio3">
-	<div class="inner">
-	  <div class="fac_img">
-            <a href="https://www.cs.toronto.edu/%7Erackoff/"><img src="people/rackoff.jpg"
-								 height="130" width="130" /></a>
-	  </div>
-	  <div class="fac_info">
-            <p> <a href="https://www.cs.toronto.edu/%7Erackoff/" target="_blank">
-		<strong>Charles Rackoff</strong></a> <br /> Cryptography,
-	      <br/> Complexity Theory</p>
-	  </div>
+        <div class="inner">
+          <div class="fac_img">
+            <a href="https://www.cs.toronto.edu/%7Erackoff/">
+              <img src="people/rackoff.jpg" height="130" width="130" /></a>
+          </div>
+          <div class="fac_info">
+            <p><a href="https://www.cs.toronto.edu/%7Erackoff/" target="_blank">
+              <strong>Charles Rackoff</strong></a> <br> Cryptography,
+              <br/> Complexity Theory
+            </p>
+          </div>
         </div>
       </div>
 
       <div id="trio2">
-	<div class="inner">
-	  <div class="fac_img">
+        <div class="inner">
+          <div class="fac_img">
             <a href="https://utoronto.academia.edu/AlasdairUrquhart" target="_blank">
-	      <img src="people/alasdair.jpg" height="130" width="130"
-		   /></a>
-	  </div>
-	  <div class="fac_info">
-            <p> <a href="https://utoronto.academia.edu/AlasdairUrquhart" target="_blank"><strong>Alasdair
-		Urquhart</strong></a> <br /> Complexity of Proofs,
-	      <br /> Logic, <br /> History of Logic
+              <img src="people/alasdair.jpg" height="130" width="130"/></a>
+          </div>
+          <div class="fac_info">
+            <p><a href="https://utoronto.academia.edu/AlasdairUrquhart" target="_blank">
+              <strong>Alasdair Urquhart</strong></a> <br> Complexity of Proofs,
+              <br> Logic, <br> History of Logic
             </p>
-	  </div>
+          </div>
         </div>
       </div>
 
     </div>
 
-<br>
+    <br>
     <div id="extended" class="clearfix shadow">
-      <a name="admin"></a>
       <h2>Administrative staff</h2>
-
       <div class="inner">
         <ul style="list-style-type:none;">
-          <li>Jankie Ramsook
+          <li>Jankie Ramsook</li>
           <!-- <li><a href="https://www.cs.toronto.edu/~vargai/" target="_blank">Ingrid Varga</a> -->
         </ul>
       </div>
 
-
+      <h2>IT Support Specialist</h2>
+      <div class="inner">
+        <ul style="list-style-type:none;">
+          <li>Malcolm Safo</li>
+        </ul>
+      </div>
     </div>
 
   <div id="footer" class="shadow">
     <p>&copy; Template design by
-				<a href="https://andreasviklund.com/" target="_blank">andreasviklund.com</a>
-		</p>
+      <a href="https://andreasviklund.com/" target="_blank">andreasviklund.com</a>
+    </p>
   </div>
 
   <script type="text/javascript">
-  	$(window).load(function() {
+    $(window).load(function() {
 
-  		//$('#nav li ul').hide().removeClass('fallback');
-  		$('#nav li').hover(
-    		function () {
-      	$('ul', this).stop().slideDown(0);
-    	},
-    	function () {
-      	$('ul', this).stop().slideUp(0);
-    	}
-  		);
+      $('#nav li').hover(
+        function () {
+          $('ul', this).stop().slideDown(0);
+        },
+        function () {
+          $('ul', this).stop().slideUp(0);
+        }
+      );
 
-  	});
+    });
   </script>
 </body>
 </html>

--- a/postdocs_visitors.html
+++ b/postdocs_visitors.html
@@ -98,7 +98,7 @@
 
       <div id="extended" class="clearfix shadow">
         <h2>Postdoc Alumni</h2>
-        <div class="inner">
+        <div class="inner" style="padding-left: 1em;">
           <ul>
             <li><a href="https://cvliaw.github.io/" target="_blank">
                 Chris Liaw</a> (Research Scientist at Google)


### PR DESCRIPTION
- Update students page with links to personal websites
- Updated theory faculty to remove Henry and Ben
- Update postdoc info
- Update faculty info
- Updated postdocs
- Update student alumni page
- Update postdoc alumni page
- Fix links on the events page and revives the link to Theory Student Seminar
- Use https and update links for home page, faculty page, and positions page
- Fix Typo in the Home Page and Add Visitors
- Update the Courses Page
- Fix formatting on alumni and postdocs page, add Malcolm on faculty page
