### PR TITLE
change harry sha url (old domain expired)

### DIFF
--- a/students.html
+++ b/students.html
@@ -96,7 +96,7 @@
                 <a href="https://www.cs.toronto.edu/%7Erosenthal/" target="_blank">Gregory Rosenthal</a>
               </li>
               <li>
-                <a href="https://harrysha.com/" target="_blank">Harry Sha</a>
+                <a href="https://www.cs.toronto.edu/%7Eshaharry/" target="_blank">Harry Sha</a>
               </li>
               <li>
                 <a href="https://www.cs.toronto.edu/%7Eashe/" target="_blank">Adrian She</a>


### PR DESCRIPTION
- add link to the reading group webpage
- change harry sha website url
there are no visible changes!
