### PR TITLE
Update students roster

### DIFF
--- a/alumni.html
+++ b/alumni.html
@@ -51,6 +51,14 @@
       <p>For a list of our postdoc alumni, click <a href="postdocs_visitors.html">here</a>.</p>
       <div class="inner" style="padding-left: 1em;">
         <ul>
+          <li><a href="https://www.cs.toronto.edu/%7Eedmonds/" target="_blank">
+              Alex Edmonds</a> (Ph.D.)</li>
+          <li><a href="https://www.seanovens.com/" target="_blank">
+              Sean Ovens</a> (Ph.D. - Postdoc at the University of Waterloo)</li>
+          <li><a href="https://www.cs.toronto.edu/%7Eemicha/" target="_blank">
+              Evi Micha</a> (Ph.D. - Postdoc at Harvard University)</li>
+          <li><a href="https://www.cs.toronto.edu/%7Erosenthal/" target="_blank">
+              Gregory Rosenthal</a> (Ph.D. - Postdoc at the University of Warwick)</li>
           <li><a href="https://www.cs.toronto.edu/%7Ecmacrury/" target="_blank">
               Calum MacRury</a> (Ph.D. - Postdoc at Columbia University)</li>
           <li><a href="https://deekshadotadil.github.io/" target="_blank">

--- a/postdocs_visitors.html
+++ b/postdocs_visitors.html
@@ -108,7 +108,7 @@
         <div class="inner" style="padding-left: 1em;">
           <ul>
             <li><a href="https://suhailsherif.github.io/" target="_blank">
-                Suhail Sherif</a>
+                Suhail Sherif</a> (Postdoc at the University of Lisbon)
             </li>
             <li><a href="https://cvliaw.github.io/" target="_blank">
                 Chris Liaw</a> (Research Scientist at Google)

--- a/students.html
+++ b/students.html
@@ -51,11 +51,9 @@
           <div class="inner">
             <ul style="list-style-type:none;">
               <li>Noah Br&uuml;stle</li>
+              <li>Ben Cookson</li>
               <li>
                 <a href="https://www.cs.toronto.edu/%7Esoroush/" target="_blank">Soroush Ebadian</a>
-              </li>
-              <li>
-                <a href="https://www.cs.toronto.edu/%7Eedmonds/" target="_blank">Alex Edmonds</a>
               </li>
               <li>
                 <a href="https://www.cs.toronto.edu/%7Exing/" target="_blank">Xing Hu</a>
@@ -67,15 +65,15 @@
                 <a href="https://www.cs.toronto.edu/%7Eckar/" target="_blank">Christodoulos Karavasilis</a>
               </li>
               <li>Jeremy Ko</li>
-              <li>
-                <a href="https://www.cs.toronto.edu/%7Edeepkush/" target="_blank">Deepanshu Kush</a>
-              </li>
             </ul>
           </div>
         </div>
         <div style="float:left;width:31%;">
           <div class="inner">
             <ul style="list-style-type:none;">
+              <li>
+                <a href="https://www.cs.toronto.edu/%7Edeepkush/" target="_blank">Deepanshu Kush</a>
+              </li>
               <li>
                 <a href="https://www.cs.toronto.edu/%7Elatifian/" target="_blank">Mohammad Latifian</a>
               </li>
@@ -86,21 +84,12 @@
               <li>Sky Li</li>
               <li>Jason (Shihao) Liu</li>
               <li>Jordan Malek</li>
-              <li>
-                <a href="https://www.cs.toronto.edu/%7Eemicha/" target="_blank">Evi Micha</a>
-              </li>
-              <li>
-                <a href="https://www.seanovens.com/" target="_blank">Sean Ovens</a>
-              </li>
             </ul>
           </div>
         </div>
         <div style="float:left;width:31%;">
           <div class="inner">
             <ul style="list-style-type:none;">
-              <li>
-                <a href="https://www.cs.toronto.edu/%7Erosenthal/" target="_blank">Gregory Rosenthal</a>
-              </li>
               <li>
                 <a href="https://www.cs.toronto.edu/%7Eshaharry/" target="_blank">Harry Sha</a>
               </li>


### PR DESCRIPTION
- Update students page with links to personal websites
- Updated theory faculty to remove Henry and Ben
- Update postdoc info
- Update faculty info
- Updated postdocs
- Update student alumni page
- Update postdoc alumni page
- Fix links on the events page and revives the link to Theory Student Seminar
- Use https and update links for home page, faculty page, and positions page
- Fix Typo in the Home Page and Add Visitors
- Update the Courses Page
- Fix formatting on alumni and postdocs page, add Malcolm on faculty page
- Update header and footer for every page
- Reformat admin staff on faculty page and unify indentation on html code
- Fix font loading bug
- Fix the padding issue in the slider in the home page
- Use UofT logo in the page title
- add link to the reading group webpage
- roei added to faculty
- correct roei's entry+pic
- updated the text about complexity theory (coordinated with Shubhangi and Swastik)
- Hide visitors and add Suhail Sherif to postdoc alumni
- change harry sha website url
- Added Akshay's image and modified faculty.html page
- Update students roster
