### PR TITLE
Update URL for Nathan Wiebe

### DIFF
--- a/faculty.html
+++ b/faculty.html
@@ -266,11 +266,11 @@
       <div id="trio3">
         <div class="inner">
           <div class="fac_img">
-            <a href="https://cqiqc.physics.utoronto.ca/people/nathan-wiebe/" target="_blank">
+            <a href="https://www.physics.utoronto.ca/members/wiebe-nathan/" target="_blank">
               <img src="people/nathan.jpg" height="130" width="130" /></a>
           </div>
           <div class="fac_info">
-            <p><a href="https://cqiqc.physics.utoronto.ca/people/nathan-wiebe/" target="_blank">
+            <p><a href="https://www.physics.utoronto.ca/members/wiebe-nathan/" target="_blank">
               <strong>Nathan Wiebe</strong></a><br> Quantum Algorithms, <br>
               Quantum Machine Learning
             </p>


### PR DESCRIPTION
- Update students page with links to personal websites
- Updated theory faculty to remove Henry and Ben
- Update postdoc info
- Update faculty info
- Updated postdocs
- Update student alumni page
- Update postdoc alumni page
- Fix links on the events page and revives the link to Theory Student Seminar
- Use https and update links for home page, faculty page, and positions page
- Fix Typo in the Home Page and Add Visitors
- Update the Courses Page
- Fix formatting on alumni and postdocs page, add Malcolm on faculty page
- Update header and footer for every page
- Reformat admin staff on faculty page and unify indentation on html code
- Fix font loading bug
- Fix the padding issue in the slider in the home page
- Use UofT logo in the page title
- add link to the reading group webpage
- roei added to faculty
- correct roei's entry+pic
- updated the text about complexity theory (coordinated with Shubhangi and Swastik)
- Hide visitors and add Suhail Sherif to postdoc alumni
- change harry sha website url
- Added Akshay's image and modified faculty.html page
- Update students roster
- Updated courses and postdoc positions for 23-24
- Postdoc applications info
- Separate Cryptography and Differential Privacy Research Description
- Update URL for Nathan Wiebe
