### PR TITLE
Sort faculty by last name and add links for staff

### DIFF
--- a/faculty.html
+++ b/faculty.html
@@ -112,6 +112,21 @@
         </div>
       </div>
 
+      <div id="trio2">
+        <div class="inner">
+          <div class="fac_img">
+            <a href="https://www.cs.toronto.edu/%7Emeel/" target="_blank">
+              <img src="people/meel.jpg" height="130" width="130" /></a>
+          </div>
+          <div class="fac_info">
+            <p><a href="https://www.cs.toronto.edu/%7Emeel/" target="_blank">
+              <strong>Kuldeep Meel</strong></a> <br> Automated Reasoning, <br>
+              Formal Methods,<br/> Databases
+            </p>
+          </div>
+        </div>
+      </div>
+
       <div id="trio3">
         <div class="inner">
           <div class="fac_img">
@@ -156,42 +171,6 @@
           </div>
         </div>
       </div>
-
-      <!-- <div id="trio2"> -->
-      <!--  <div class="inner"> -->
-      <!--    <div class="fac_img"> -->
-      <!--      <a href="https://www.math.toronto.edu/rossman/" target="_blank"> -->
-      <!--        <img src="people/rossman.jpg" class="fac_img" -->
-      <!--       width="130" height="130" -->
-      <!--       /></a> -->
-      <!--    </div> -->
-      <!--    <div class="fac_info"> -->
-      <!--      <p> <a href="https://www.math.toronto.edu/rossman/" target="_blank"><strong>Benjamin Rossman</strong> -->
-      <!--        </a> <br> Circuit Complexity, <br> -->
-      <!--        Logic<br/> -->
-      <!--        (On leave) -->
-      <!--      </p> -->
-      <!--    </div> -->
-      <!--  </div> -->
-      <!-- </div> -->
-
-      
-
-      <div id="trio2">
-        <div class="inner">
-          <div class="fac_img">
-            <a href="https://www.cs.toronto.edu/%7Emeel/" target="_blank">
-              <img src="people/meel.jpg" height="130" width="130" /></a>
-          </div>
-          <div class="fac_info">
-            <p><a href="https://www.cs.toronto.edu/%7Emeel/" target="_blank">
-              <strong>Kuldeep Meel</strong></a> <br> Automated Reasoning, <br>
-              Formal Methods,<br/> Databses
-            </p>
-          </div>
-        </div>
-      </div>
-      
 
       <div id="trio2">
         <div class="inner">
@@ -389,8 +368,12 @@
       <h2>Administrative Staff</h2>
       <div class="inner" style="padding-left:1em;">
         <ul>
-          <li>Jankie Ramsook (Faculty Services Support Assistant)</li>
-          <li>Malcolm Safo (Computer Science Support Specialist)</li>
+          <li>
+            <a href="https://web.cs.toronto.edu/people/staff-directory" target="_blank">Jankie Ramsook</a> (Faculty Services Support Assistant)
+          </li>
+          <li>
+            <a href="https://web.cs.toronto.edu/people/staff-directory" target="_blank">Malcolm Safo</a> (Computer Science Support Specialist)
+          </li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
- Update students page with links to personal websites
- Updated theory faculty to remove Henry and Ben
- Update postdoc info
- Update faculty info
- Updated postdocs
- Update student alumni page
- Update postdoc alumni page
- Fix links on the events page and revives the link to Theory Student Seminar
- Use https and update links for home page, faculty page, and positions page
- Fix Typo in the Home Page and Add Visitors
- Update the Courses Page
- Fix formatting on alumni and postdocs page, add Malcolm on faculty page
- Update header and footer for every page
- Reformat admin staff on faculty page and unify indentation on html code
- Fix font loading bug
- Fix the padding issue in the slider in the home page
- Use UofT logo in the page title
- add link to the reading group webpage
- roei added to faculty
- correct roei's entry+pic
- updated the text about complexity theory (coordinated with Shubhangi and Swastik)
- Hide visitors and add Suhail Sherif to postdoc alumni
- change harry sha website url
- Added Akshay's image and modified faculty.html page
- Update students roster
- Updated courses and postdoc positions for 23-24
- Postdoc applications info
- Separate Cryptography and Differential Privacy Research Description
- Update URL for Nathan Wiebe
- Added a new postdoc position to work with Sushant
- Added Kuldeep
- Added Kuldeep to faculty
- Sort faculty by last name and add links for staff
