### PR TITLE
Add links to students' personal websites

### DIFF
--- a/students.html
+++ b/students.html
@@ -50,8 +50,12 @@
         <div style="float:left;width:31%;">
           <div class="inner">
             <ul style="list-style-type:none;">
-              <li>Noah Br&uuml;stle</li>
-              <li>Ben Cookson</li>
+              <li>
+                <a href="https://www.cs.toronto.edu/%7Enoah/" target="_blank">Noah Br&uuml;stle</a>
+              </li>
+              <li>
+                <a href="https://www.cs.toronto.edu/%7Ebcookson/" target="_blank">Ben Cookson</a>
+              </li>
               <li>
                 <a href="https://www.cs.toronto.edu/%7Esoroush/" target="_blank">Soroush Ebadian</a>
               </li>
@@ -64,7 +68,9 @@
               <li>
                 <a href="https://www.cs.toronto.edu/%7Eckar/" target="_blank">Christodoulos Karavasilis</a>
               </li>
-              <li>Jeremy Ko</li>
+              <li>
+                <a href="https://www.cs.toronto.edu/%7Ejerko/" target="_blank">Jeremy Ko</a>
+              </li>
             </ul>
           </div>
         </div>
@@ -80,10 +86,18 @@
               <li>
                 <a href="https://www.cs.toronto.edu/%7Elawrenceli/" target="_blank">Lawrence Li</a>
               </li>
-              <li>Lily Li</li>
-              <li>Sky Li</li>
-              <li>Jason (Shihao) Liu</li>
-              <li>Jordan Malek</li>
+              <li>
+                <a href="https://www.cs.toronto.edu/%7Exinyuan/" target="_blank">Lily Li</a>
+              </li>
+              <li>
+                <a href="https://www.cs.toronto.edu/%7Esky/" target="_blank">Sky Li</a>
+              </li>
+              <li>
+                <a href="https://www.cs.toronto.edu/%7Eshliu/" target="_blank">Jason (Shihao) Liu</a>
+              </li>
+              <li>
+                <a href="https://www.cs.toronto.edu/%7Ejmalek/" target="_blank">Jordan Malek</a>
+              </li>
             </ul>
           </div>
         </div>
@@ -102,8 +116,12 @@
               <li>
                 <a href="https://devansh99.github.io/" target="_blank">Devansh Shringi</a>
               </li>
-              <li>Haohua Tang</li>
-              <li>Yibin Zhao</li>
+              <li>
+                <a href="https://www.cs.toronto.edu/%7Ekyurem/" target="_blank">Haohua Tang</a>
+              </li>
+              <li>
+                <a href="https://www.cs.toronto.edu/%7Eybzhao/" target="_blank">Yibin Zhao</a>
+              </li>
             </ul>
           </div>
         </div>
@@ -113,7 +131,7 @@
         <p>
           &copy; Template design by <a href="https://andreasviklund.com/"
           target="_blank">andreasviklund.com</a> <br>
-          &copy; 2023 Department of Computer Science, University of Toronto
+          &copy; 2023 - 2024 Department of Computer Science, University of Toronto
         </p>
       </div>
     </div>


### PR DESCRIPTION
- Update students page with links to personal websites
- Updated theory faculty to remove Henry and Ben
- Update postdoc info
- Update faculty info
- Updated postdocs
- Update student alumni page
- Update postdoc alumni page
- Fix links on the events page and revives the link to Theory Student Seminar
- Use https and update links for home page, faculty page, and positions page
- Fix Typo in the Home Page and Add Visitors
- Update the Courses Page
- Fix formatting on alumni and postdocs page, add Malcolm on faculty page
- Update header and footer for every page
- Reformat admin staff on faculty page and unify indentation on html code
- Fix font loading bug
- Fix the padding issue in the slider in the home page
- Use UofT logo in the page title
- add link to the reading group webpage
- roei added to faculty
- correct roei's entry+pic
- updated the text about complexity theory (coordinated with Shubhangi and Swastik)
- Hide visitors and add Suhail Sherif to postdoc alumni
- change harry sha website url
- Added Akshay's image and modified faculty.html page
- Update students roster
- Updated courses and postdoc positions for 23-24
- Postdoc applications info
- Separate Cryptography and Differential Privacy Research Description
- Update URL for Nathan Wiebe
- Added a new postdoc position to work with Sushant
- Added Kuldeep
- Added Kuldeep to faculty
- Sort faculty by last name and add links for staff
- Add links to students' personal websites
