### PR TITLE
Update footer to year 2024

### DIFF
--- a/alumni.html
+++ b/alumni.html
@@ -154,13 +154,13 @@
       </div>
     </div>
 
-    <div id="footer" class="shadow">
-        <p>
-          &copy; Template design by <a href="https://andreasviklund.com/"
-          target="_blank">andreasviklund.com</a> <br>
-          &copy; 2023 Department of Computer Science, University of Toronto
-        </p>
-    </div>
+    <footer id="footer" class="shadow">
+      <p>
+        &copy; Template design by <a href="https://andreasviklund.com/"
+        target="_blank">andreasviklund.com</a> <br>
+        &copy; 2023 - 2024 Department of Computer Science, University of Toronto
+      </p>
+    </footer>
   </div>
 
   <script type="text/javascript">

--- a/courses.html
+++ b/courses.html
@@ -225,13 +225,13 @@
     </ul>
   </div>
 
-  <div id="footer" class="shadow">
+  <footer id="footer" class="shadow">
     <p>
       &copy; Template design by <a href="https://andreasviklund.com/"
       target="_blank">andreasviklund.com</a> <br>
-      &copy; 2023 Department of Computer Science, University of Toronto
+      &copy; 2023 - 2024 Department of Computer Science, University of Toronto
     </p>
-  </div>
+  </footer>
 </div>
 
 <script type="text/javascript">

--- a/events.html
+++ b/events.html
@@ -62,13 +62,13 @@
     <p><a href="http://www.fields.utoronto.ca/calendar" target="_blank">Fields Institute Events</a></p> <!-- does not support https -->
   </div>
 
-  <div id="footer" class="shadow">
+  <footer id="footer" class="shadow">
     <p>
       &copy; Template design by <a href="https://andreasviklund.com/"
       target="_blank">andreasviklund.com</a> <br>
-      &copy; 2023 Department of Computer Science, University of Toronto
+      &copy; 2023 - 2024 Department of Computer Science, University of Toronto
     </p>
-  </div>
+  </footer>
 </div>
 
 <script type="text/javascript">

--- a/faculty.html
+++ b/faculty.html
@@ -378,13 +378,13 @@
       </div>
     </div>
 
-  <div id="footer" class="shadow">
+  <footer id="footer" class="shadow">
     <p>
       &copy; Template design by <a href="https://andreasviklund.com/"
       target="_blank">andreasviklund.com</a> <br>
-      &copy; 2023 Department of Computer Science, University of Toronto
+      &copy; 2023 - 2024 Department of Computer Science, University of Toronto
     </p>
-  </div>
+  </footer>
 
   <script type="text/javascript">
     $(window).load(function() {

--- a/index.html
+++ b/index.html
@@ -87,13 +87,13 @@
         </p>
       </div>
 
-      <div id="footer" class="shadow">
+      <footer id="footer" class="shadow">
         <p>
           &copy; Template design by <a href="https://andreasviklund.com/"
           target="_blank">andreasviklund.com</a> <br>
-          &copy; 2023 Department of Computer Science, University of Toronto
+          &copy; 2023 - 2024 Department of Computer Science, University of Toronto
         </p>
-      </div>
+      </footer>
     </div>
 
     <script type="text/javascript">

--- a/positions.html
+++ b/positions.html
@@ -100,13 +100,13 @@
     </p>
   </div>
 
-  <div id="footer" class="shadow">
+  <footer id="footer" class="shadow">
     <p>
       &copy; Template design by <a href="https://andreasviklund.com/"
       target="_blank">andreasviklund.com</a> <br>
-      &copy; 2023 Department of Computer Science, University of Toronto
+      &copy; 2023 - 2024 Department of Computer Science, University of Toronto
     </p>
-  </div>
+  </footer>
 </div>
 
 <script type="text/javascript">

--- a/postdocs_visitors.html
+++ b/postdocs_visitors.html
@@ -300,13 +300,13 @@
 
       <br>
 
-      <div id="footer" class="shadow">
+      <footer id="footer" class="shadow">
         <p>
           &copy; Template design by <a href="https://andreasviklund.com/"
           target="_blank">andreasviklund.com</a> <br>
-          &copy; 2023 Department of Computer Science, University of Toronto
+          &copy; 2023 - 2024 Department of Computer Science, University of Toronto
         </p>
-      </div>
+      </footer>
     </div>
 
     <script type="text/javascript">

--- a/research.html
+++ b/research.html
@@ -234,13 +234,13 @@
     </p>
   </div>
 
-  <div id="footer" class="shadow">
+  <footer id="footer" class="shadow">
     <p>
       &copy; Template design by <a href="https://andreasviklund.com/"
       target="_blank">andreasviklund.com</a> <br>
-      &copy; 2023 Department of Computer Science, University of Toronto
+      &copy; 2023 - 2024 Department of Computer Science, University of Toronto
     </p>
-  </div>
+  </footer>
 </div>
 
 <script type="text/javascript">

--- a/students.html
+++ b/students.html
@@ -127,13 +127,13 @@
         </div>
       </div>
 
-      <div id="footer" class="shadow">
+      <footer id="footer" class="shadow">
         <p>
           &copy; Template design by <a href="https://andreasviklund.com/"
           target="_blank">andreasviklund.com</a> <br>
           &copy; 2023 - 2024 Department of Computer Science, University of Toronto
         </p>
-      </div>
+      </footer>
     </div>
 
     <script type="text/javascript">


### PR DESCRIPTION
- Update students page with links to personal websites
- Updated theory faculty to remove Henry and Ben
- Update postdoc info
- Update faculty info
- Updated postdocs
- Update student alumni page
- Update postdoc alumni page
- Fix links on the events page and revives the link to Theory Student Seminar
- Use https and update links for home page, faculty page, and positions page
- Fix Typo in the Home Page and Add Visitors
- Update the Courses Page
- Fix formatting on alumni and postdocs page, add Malcolm on faculty page
- Update header and footer for every page
- Reformat admin staff on faculty page and unify indentation on html code
- Fix font loading bug
- Fix the padding issue in the slider in the home page
- Use UofT logo in the page title
- add link to the reading group webpage
- roei added to faculty
- correct roei's entry+pic
- updated the text about complexity theory (coordinated with Shubhangi and Swastik)
- Hide visitors and add Suhail Sherif to postdoc alumni
- change harry sha website url
- Added Akshay's image and modified faculty.html page
- Update students roster
- Updated courses and postdoc positions for 23-24
- Postdoc applications info
- Separate Cryptography and Differential Privacy Research Description
- Update URL for Nathan Wiebe
- Added a new postdoc position to work with Sushant
- Added Kuldeep
- Added Kuldeep to faculty
- Sort faculty by last name and add links for staff
- Add links to students' personal websites
- Update footer to year 2024
